### PR TITLE
`pkg_resources` removal, bumped minimum required Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "maptide"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/python/maptide/cli.py
+++ b/python/maptide/cli.py
@@ -2,7 +2,7 @@ import argparse
 import math
 import sys
 import csv
-import pkg_resources
+from importlib.metadata import version
 from . import api
 
 
@@ -60,7 +60,7 @@ def run():
         "-v",
         "--version",
         action="version",
-        version=pkg_resources.get_distribution("maptide").version,
+        version=version("maptide"),
     )
     parser.add_argument(
         "-r",


### PR DESCRIPTION
- `pkg_resources` was deprecated in Python 3.12, switching to usage of `importlib` for determining version number.
- Bumped minimum supported Python version to 3.9, as this is the minimum version now supported by Python themselves.